### PR TITLE
Updated Footer Links on Privacy Page to Match Website Theme

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -7,6 +7,35 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - ML Fusion Labs</title>
     <link rel="stylesheet" href="style.css">
+    <style>
+    footer {
+        background: #333;
+        color: white;
+        text-align: center;
+        padding: 20px 0;
+        margin-top: auto; /* Push footer to bottom */
+    }
+    .footer-container {
+        max-width: 800px;
+        margin: auto;
+        padding: 0 20px;
+    }
+    .footer-links, .footer-socials {
+        margin: 10px 0;
+    }
+    .footer-links a, .footer-socials a {
+        color: white;
+        text-decoration: none;
+        margin: 0 10px;
+        transition: color 0.3s; /* Add transition for hover effect */
+    }
+    .footer-links a:hover, .footer-socials a:hover {
+        color: #007BFF; /* Change color on hover */
+    }
+    .footer-contact {
+        margin: 10px 0;
+    }
+</style>
 </head>
 <body>
     <header>


### PR DESCRIPTION
fixes #91 

Changed the default blue footer links on the privacy page to fit the overall theme of the website.

Ensured that the new link colors align with the design guidelines to provide a consistent user experience.

BEFORE SCREENSHOT (Containing issue) :
![Screenshot 2024-10-02 184932](https://github.com/user-attachments/assets/ea7a52c2-29ac-41dd-9e1b-1f20d464544e)

AFTER SCREENSHOT (Issue Fixed):
![image](https://github.com/user-attachments/assets/77b9d2d9-48d2-4cae-a5e7-4dbf37badffc)
