### PR TITLE
Background image added in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -1212,10 +1212,11 @@ body.dark-mode .contact-us {
 
 /* About page dark theme */
 body.dark-mode .about-hero {
-  background: black;
+  background: url('robot-2301646_1280.jpg') no-repeat center center; /* Set the background image */
+  background-size: cover; /* Ensure the background image covers the entire div */
   color: white;
+  background-position: top;
 }
-
 body.dark-mode .about-us {
   margin-top: 2px;
   background: black;


### PR DESCRIPTION
background image which was not available in dark mode is now added just like light mode
fixes #380

![image](https://github.com/user-attachments/assets/fc5dfccb-ac93-4fa8-9357-51d4298025eb)
