### PR TITLE
fixed the banner background image of about us page

### DIFF
--- a/style.css
+++ b/style.css
@@ -1788,7 +1788,7 @@ header nav ul li a {
 
 /* About Us Page Specific Styles */
 .about-hero {
-  background-image: url("https://source.unsplash.com/1600x900/?team,collaboration");
+  background: url('robot-2301646_1280.jpg') no-repeat center center; /* Set the background image */
   background-size: cover;
   background-position: center;
   color: white;


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Issues Identification

Closes: #487 

## Description
I had found one issue with about us page. The banner Image for light theme was not visible.
### Summary
To fix the issue #487 I had done few changes to the style sheet to accommodate the image feature within the page.

### Details
 I have made changes to the banner class and have added correct syntax and link for the banner background image.

## Types of Changes

_Please check the boxes that apply_

- [✓] Bugfix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe):

## Checklist

_Please check the boxes that apply_

- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] I have commented my code, particularly in hard-to-understand areas
- [✓] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
- [✓] My changes do not break the current system and pass all existing test cases
- [✓] I have added tests that prove my fix is effective or that my feature works
- [✓] New and existing unit tests pass locally with my changes

## Screenshots
![Screenshot 2024-10-12 171347](https://github.com/user-attachments/assets/886cdc60-ec94-4914-9285-27d5e28dc548)

## Additional Information
As part of Issue #487 I was assigned the task to fix the issue.
Please provide any other information that is relevant to this pull request.

<!-- We're looking forward to merging your contribution!! -->