### PR TITLE
[FIX] : Email Page form Name validation 

### DIFF
--- a/pages/email.html
+++ b/pages/email.html
@@ -141,7 +141,9 @@
 
             <form action="/submit-form" method="POST">
                 <label for="name">Name:</label>
-                <input type="text" id="name" name="name" placeholder="Your Name" required>
+                <input type="text" id="name" name="name" placeholder="Your Name" required pattern="[a-zA-Z ]+"
+            oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')"
+            oninput="this.setCustomValidity('')">
 
                 <label for="email">Email:</label>
                 <input type="email" id="email" name="email" placeholder="Your Email" required>


### PR DESCRIPTION
<!-- Thank you for sending a pull request :heart: -->

## Issues Identification

Closes: #1037

## Description

### Summary
The "Name" field in the Contact Us form should only accept alphabetical letters (a-z, A-Z).



## Types of Changes



- [x] Bugfix (non-breaking change that fixes an issue)

## Checklist



- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] My changes do not break the current system and pass all existing test cases
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots

## Before 
![image](https://github.com/user-attachments/assets/c8a64a5c-af2e-4782-aa43-b95af7e2cf32)

## After 
![image](https://github.com/user-attachments/assets/2e49b02a-6007-48ab-bf0d-2e5e93157c66)




<!-- We're looking forward to merging your contribution!! -->